### PR TITLE
Make Nil values be logged as 'null'

### DIFF
--- a/bin/cute_log
+++ b/bin/cute_log
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'colorize'
 require 'json'
-require 'awesome_print'
+require 'amazing_print'
 require 'cute_logger'
 
 awesome = true

--- a/cute_logger.gemspec
+++ b/cute_logger.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cute_logger/version'
 
@@ -22,11 +21,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'awesome_print', '~> 1'
+  spec.add_runtime_dependency 'amazing_print', '~> 1.4'
+  spec.add_runtime_dependency 'colorize', '~> 0.8'
   spec.add_runtime_dependency 'utf8_converter', '~> 0.1'
-   spec.add_runtime_dependency 'colorize', '~> 0.8.1'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 2.3'
   spec.add_development_dependency 'minitest', '~> 5'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'simplecov', '~> 0.21'
 end

--- a/lib/cute_logger.rb
+++ b/lib/cute_logger.rb
@@ -113,3 +113,10 @@ class Hash
     Hash[map { |key, value| [key.to_log_format, value.to_log_format] }]
   end
 end
+
+# nil values should be logged as nulls
+class NilClass
+  def to_log_format
+    nil
+  end
+end

--- a/lib/cute_logger.rb
+++ b/lib/cute_logger.rb
@@ -1,25 +1,28 @@
 require 'cute_logger/version'
 require 'logger'
 require 'json'
-require 'awesome_print'
 require 'utf8_converter'
 
 # This module defines the functionality the the CuteLogger gem
 module CuteLogger
   SEVERITY = {
     'DEBUG' => Logger::DEBUG,
-    'INFO'  => Logger::INFO,
-    'WARN'  => Logger::WARN,
+    'INFO' => Logger::INFO,
+    'WARN' => Logger::WARN,
     'ERROR' => Logger::ERROR,
     'FATAL' => Logger::FATAL
   }
 
   def self.setup(settings = {})
-    @logger = Logger.new(
-      ENV['CUTE_LOGGER_FILENAME'] || settings[:filename] || 'application.log',
-      ENV['CUTE_LOGGER_SHIFT_AGE'] || settings[:shift_age] || 7,
-      ENV['CUTE_LOGGER_SHIFT_SIZE'] || settings[:shift_size] || 1024 * 1024 * 1024 # One gigabyte
-    )
+    @logger = if ENV['CUTE_LOGGER_STDOUT']
+                Logger.new($stdout)
+              else
+                Logger.new(
+                  ENV['CUTE_LOGGER_FILENAME'] || settings[:filename] || 'application.log',
+                  ENV['CUTE_LOGGER_SHIFT_AGE'] || settings[:shift_age] || 7,
+                  ENV['CUTE_LOGGER_SHIFT_SIZE'] || settings[:shift_size] || 1024 * 1024 * 1024 # One gigabyte
+                )
+              end
     @logger.sev_threshold = severity(ENV['CUTE_LOGGER_SEVERITY'] || settings[:severity])
     @logger.datetime_format = '%Y-%m-%d %H:%M:%S'
     @logger.formatter = proc do |severity, datetime, progname, msg|
@@ -34,7 +37,8 @@ module CuteLogger
 
   def self.severity(text)
     return Logger::INFO unless text
-    fail("Unknown logger severity: #{text}") unless SEVERITY[text.upcase]
+    raise("Unknown logger severity: #{text}") unless SEVERITY[text.upcase]
+
     SEVERITY[text.upcase]
   end
 

--- a/lib/cute_logger/version.rb
+++ b/lib/cute_logger/version.rb
@@ -1,5 +1,5 @@
 
 # Partial module to define the version of the gem
 module CuteLogger
-  VERSION = '0.1.9'
+  VERSION = '0.2.0'
 end

--- a/test/cute_logger_test.rb
+++ b/test/cute_logger_test.rb
@@ -17,6 +17,7 @@ class CuteLoggerTest < Minitest::Test
     log_info('A nasty error', id: '123')
     log_info('TestApp') { 'LogC' }
     log_debug('LogD')
+    log_info(nil)
 
     data = File.readlines('application.log')
     assert_match(/LogA/, data[1])
@@ -24,6 +25,7 @@ class CuteLoggerTest < Minitest::Test
     assert_match(/nasty/, data[3])
     assert_match(/TestApp/, data[4])
     assert_match(/LogD/, data[5])
+    assert_match(/null/, data[6])
   end
 
   def test_exception_logging

--- a/test/cute_logger_test.rb
+++ b/test/cute_logger_test.rb
@@ -32,7 +32,7 @@ class CuteLoggerTest < Minitest::Test
     log_info(StandardError.new('ErrorA'))
     begin
       # Triggering an error on purpose
-      x + 1
+      x
       assert(false, 'This line should not run')
     rescue => error
       log_fatal('ErrorB', error)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'cute_logger'
 


### PR DESCRIPTION
When there was logged a value that was nil, it displayed an empty string, which may lead to confusion.